### PR TITLE
Small safe area fix for UpgradeInterstitialView.

### DIFF
--- a/Sources/UpgradeInterstitialFeature/UpgradeInterstitialView.swift
+++ b/Sources/UpgradeInterstitialFeature/UpgradeInterstitialView.swift
@@ -244,7 +244,10 @@ public struct UpgradeInterstitialView: View {
       .onAppear { viewStore.send(.onAppear) }
       .applying {
         if self.colorScheme == .dark {
-          $0.background(Color.isowordsBlack)
+          $0.background(
+            Color.isowordsBlack
+              .ignoresSafeArea()
+          )
         } else {
           $0.background(
             LinearGradient(


### PR DESCRIPTION
Turns out the safe areas weren’t being ignored in dark mode.

![IMG_B8F0E7781AA4-1](https://user-images.githubusercontent.com/1276296/111508056-a6f9ee80-8721-11eb-94a0-a92f2617d647.jpeg)
