### PR TITLE
Truncate nav title

### DIFF
--- a/Sources/GameCore/Views/GameNavView.swift
+++ b/Sources/GameCore/Views/GameNavView.swift
@@ -77,9 +77,7 @@ struct GameNavView: View {
       VStack {
         GameNavView(
           store: .init(
-            initialState: .init(
-              inProgressGame: .mock
-            ),
+            initialState: .init(inProgressGame: .mock),
             reducer: .empty,
             environment: ()
           )

--- a/Sources/GameCore/Views/GameNavView.swift
+++ b/Sources/GameCore/Views/GameNavView.swift
@@ -30,6 +30,8 @@ struct GameNavView: View {
       Button(action: { self.viewStore.send(.trayButtonTapped, animation: .default) }) {
         HStack {
           Text(self.viewStore.trayTitle)
+            .lineLimit(1)
+            .truncationMode(.tail)
 
           Spacer()
 
@@ -75,7 +77,9 @@ struct GameNavView: View {
       VStack {
         GameNavView(
           store: .init(
-            initialState: .init(inProgressGame: .mock),
+            initialState: .init(
+              inProgressGame: .mock
+            ),
             reducer: .empty,
             environment: ()
           )

--- a/Sources/GameCore/Views/GameNavView.swift
+++ b/Sources/GameCore/Views/GameNavView.swift
@@ -31,7 +31,6 @@ struct GameNavView: View {
         HStack {
           Text(self.viewStore.trayTitle)
             .lineLimit(1)
-            .truncationMode(.tail)
 
           Spacer()
 


### PR DESCRIPTION
Prevents the nav title from flowing to two lines with big fonts:

![image](https://user-images.githubusercontent.com/135203/111519383-42846280-8714-11eb-8b6d-424e0594f475.png)
