### PR TITLE
Update `db-drop` to `clean-db` in reset warning.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ define POSTGRES_WARNING
 
      Reset at any time with:
 
-       $$ \033[1mmake\033[0m \033[38;5;66mdb-drop\033[0m
+       $$ \033[1mmake\033[0m \033[38;5;66mclean-db\033[0m
 
 endef
 export POSTGRES_WARNING


### PR DESCRIPTION
Noticed this when trying to bootstrap.

Now, it should read:

>   ⚠️  Checking on PostgreSQL...
>   ✅ PostgreSQL is up and running!
>   ⚠️  Local databases aren't configured! Creating isowords user/databases...
> 
>      Reset at any time with:
> 
>        $ make clean-db