### PR TITLE
Deduplicate words when bootstrapping from `/usr/share/dict/words`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ words-import:
 ifdef PRIVATE
 	@curl -o $(DICTIONARY_GZIP) $(DICTIONARY_URL)
 else
-	@cat /usr/share/dict/words | tr a-z A-Z | grep '^[A-Z]\{3,\}$$' | gzip > $(DICTIONARY_GZIP)
+	@cat /usr/share/dict/words | tr a-z A-Z | uniq | grep '^[A-Z]\{3,\}$$' | gzip > $(DICTIONARY_GZIP)
 endif
 
 DICTIONARY_DB = Sources/DictionarySqliteClient/Dictionaries/Words.en.db


### PR DESCRIPTION
Partially addresses #9 and #10.

Didn't want to address the alter role errors at the end because it seems like running `db` in `bootstrap-server` is required in the "private" branch whereas in the "public" branch, `check-dependencies-server` runs it if required.