### PR TITLE
Use `sort -u` instead of `uniq` to deduplicate when bootstrapping.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ words-import:
 ifdef PRIVATE
 	@curl -o $(DICTIONARY_GZIP) $(DICTIONARY_URL)
 else
-	@cat /usr/share/dict/words | tr a-z A-Z | uniq | grep '^[A-Z]\{3,\}$$' | gzip > $(DICTIONARY_GZIP)
+	@cat /usr/share/dict/words | tr a-z A-Z | sort -u | grep '^[A-Z]\{3,\}$$' | gzip > $(DICTIONARY_GZIP)
 endif
 
 DICTIONARY_DB = Sources/DictionarySqliteClient/Dictionaries/Words.en.db


### PR DESCRIPTION
Hopefully this addresses the "doesn't work in Ubuntu" comment in #13.