### PR TITLE
Prevent double removal on client and allow it on server.

### DIFF
--- a/Sources/GameCore/GameCore.swift
+++ b/Sources/GameCore/GameCore.swift
@@ -622,6 +622,9 @@ extension GameState {
   }
 
   mutating func removeCube(at index: LatticePoint, playedAt: Date) {
+    guard self.cubes[index].isInPlay
+    else { return }
+
     self.cubes[index].wasRemoved = true
     self.moves.append(
       Move(

--- a/Sources/SharedModels/Verification.swift
+++ b/Sources/SharedModels/Verification.swift
@@ -72,12 +72,12 @@ public func verify(
     } else { return nil }
 
   case let .removedCube(point):
-
-
-
     if
       puzzle[point].isInPlay
-    || (moveIndex > 0 && moves[moveIndex - 1].type == move.type)
+        // NB: Allow "removing" an out of play cube if it was removed in the previous move. This
+        //     is to work around a race condition in the client where quickly tapping multiple times
+        //     can accidentally remove a single cube twice.
+        || (moveIndex > 0 && moves[moveIndex - 1].type == move.type)
     {
       apply(move: move, to: &puzzle)
       return .init(cubeFaces: [], foundWord: nil, score: 0)

--- a/Sources/SharedModels/Verification.swift
+++ b/Sources/SharedModels/Verification.swift
@@ -1,4 +1,4 @@
-public struct VerifiedPuzzleResult {
+public struct VerifiedPuzzleResult: Equatable {
   public var totalScore = 0
   public var verifiedMoves: [VerifiedMoveResult] = []
 }
@@ -17,8 +17,13 @@ public func verify(
   var puzzle = Puzzle(archivableCubes: puzzle)
 
   var result = VerifiedPuzzleResult()
-  for move in moves {
-    if let moveResult = verify(move: move, playedOn: &puzzle, isValidWord: isValidWord) {
+  for index in moves.indices {
+    if let moveResult = verify(
+        moveIndex: index,
+        moves: moves,
+        playedOn: &puzzle,
+        isValidWord: isValidWord
+    ) {
       result.totalScore += moveResult.score
       result.verifiedMoves.append(moveResult)
     } else {
@@ -31,10 +36,13 @@ public func verify(
 }
 
 public func verify(
-  move: Move,
+  moveIndex: Int,
+  moves: Moves,
   playedOn puzzle: inout Puzzle,
   isValidWord: (String) -> Bool
 ) -> VerifiedMoveResult? {
+  let move = moves[moveIndex]
+
   switch move.type {
   case let .playedWord(cubeFaces):
     guard cubeFaces.count == Set(cubeFaces).count
@@ -61,12 +69,16 @@ public func verify(
       // TODO: this score should be computed from the string rather than using what is handed us.
       //       in fact maybe we need an ArchivableMove to remove that info?
       return .init(cubeFaces: cubeFaces, foundWord: foundWord, score: move.score)
-    } else {
-      return nil
-    }
+    } else { return nil }
 
   case let .removedCube(point):
-    if puzzle[point].isInPlay {
+
+
+
+    if
+      puzzle[point].isInPlay
+    || (moveIndex > 0 && moves[moveIndex - 1].type == move.type)
+    {
       apply(move: move, to: &puzzle)
       return .init(cubeFaces: [], foundWord: nil, score: 0)
     } else {

--- a/Sources/SharedModels/Verification.swift
+++ b/Sources/SharedModels/Verification.swift
@@ -1,4 +1,4 @@
-public struct VerifiedPuzzleResult: Equatable {
+public struct VerifiedPuzzleResult {
   public var totalScore = 0
   public var verifiedMoves: [VerifiedMoveResult] = []
 }

--- a/Tests/SharedModelsTests/VerificationTests.swift
+++ b/Tests/SharedModelsTests/VerificationTests.swift
@@ -39,11 +39,6 @@ class VerificationTests: XCTestCase {
           )
         ]
       )
-//      (
-//        cubeFaces: ,
-//        foundWord: "QUA",
-//        score: 10
-//      )
     )
   }
 

--- a/Tests/SharedModelsTests/VerificationTests.swift
+++ b/Tests/SharedModelsTests/VerificationTests.swift
@@ -1,59 +1,72 @@
 import XCTest
-
 @testable import SharedModels
 
 class VerificationTests: XCTestCase {
   func testWordLength() {
-    var puzzle = Puzzle.mock
+    var puzzle = ArchivablePuzzle.mock
     puzzle.2.2.2.left.letter = "QU"
     puzzle.2.2.2.right.letter = "A"
 
     let result = verify(
-      move: .init(
-        playedAt: .init(),
-        playerIndex: nil,
-        reactions: nil,
-        score: 10,
-        type: .playedWord([
-          .init(index: .init(x: .two, y: .two, z: .two), side: .left),
-          .init(index: .init(x: .two, y: .two, z: .two), side: .right),
-        ])
-      ),
-      playedOn: &puzzle,
+      moves: [
+        .init(
+          playedAt: .init(),
+          playerIndex: nil,
+          reactions: nil,
+          score: 10,
+          type: .playedWord([
+            .init(index: .init(x: .two, y: .two, z: .two), side: .left),
+            .init(index: .init(x: .two, y: .two, z: .two), side: .right),
+          ])
+        )
+      ],
+      playedOn: puzzle,
       isValidWord: { _ in true }
     )
 
     XCTAssertEqual(
       result,
       .init(
-        cubeFaces: [
-          .init(index: .init(x: .two, y: .two, z: .two), side: .left),
-          .init(index: .init(x: .two, y: .two, z: .two), side: .right),
-        ],
-        foundWord: "QUA",
-        score: 10
+        totalScore: 10,
+        verifiedMoves: [
+          .init(
+            cubeFaces: [
+              .init(index: .init(x: .two, y: .two, z: .two), side: .left),
+              .init(index: .init(x: .two, y: .two, z: .two), side: .right),
+            ],
+            foundWord: "QUA",
+            score: 10
+          )
+        ]
       )
+//      (
+//        cubeFaces: ,
+//        foundWord: "QUA",
+//        score: 10
+//      )
     )
   }
 
   func testDuplicatesNotAllowed() {
-    var puzzle = Puzzle.mock
+    var puzzle = ArchivablePuzzle.mock
     puzzle.2.2.2.left.letter = "T"
     puzzle.2.2.2.right.letter = "O"
 
     let result = verify(
-      move: .init(
-        playedAt: .init(),
-        playerIndex: nil,
-        reactions: nil,
-        score: 10,
-        type: .playedWord([
-          .init(index: .init(x: .two, y: .two, z: .two), side: .left),
-          .init(index: .init(x: .two, y: .two, z: .two), side: .right),
-          .init(index: .init(x: .two, y: .two, z: .two), side: .left),
-        ])
-      ),
-      playedOn: &puzzle,
+      moves: [
+        .init(
+          playedAt: .init(),
+          playerIndex: nil,
+          reactions: nil,
+          score: 10,
+          type: .playedWord([
+            .init(index: .init(x: .two, y: .two, z: .two), side: .left),
+            .init(index: .init(x: .two, y: .two, z: .two), side: .right),
+            .init(index: .init(x: .two, y: .two, z: .two), side: .left),
+          ])
+        )
+      ],
+      playedOn: puzzle,
       isValidWord: { _ in true }
     )
 
@@ -64,24 +77,26 @@ class VerificationTests: XCTestCase {
   }
 
   func testWordNotInDictionary() {
-    var puzzle = Puzzle.mock
+    var puzzle = ArchivablePuzzle.mock
     puzzle.2.2.2.left.letter = "C"
     puzzle.2.2.2.right.letter = "A"
     puzzle.2.2.2.top.letter = "B"
 
     let result = verify(
-      move: .init(
-        playedAt: .init(),
-        playerIndex: nil,
-        reactions: nil,
-        score: 10,
-        type: .playedWord([
-          .init(index: .init(x: .two, y: .two, z: .two), side: .left),
-          .init(index: .init(x: .two, y: .two, z: .two), side: .right),
-          .init(index: .init(x: .two, y: .two, z: .two), side: .top),
-        ])
-      ),
-      playedOn: &puzzle,
+      moves: [
+        .init(
+          playedAt: .init(),
+          playerIndex: nil,
+          reactions: nil,
+          score: 10,
+          type: .playedWord([
+            .init(index: .init(x: .two, y: .two, z: .two), side: .left),
+            .init(index: .init(x: .two, y: .two, z: .two), side: .right),
+            .init(index: .init(x: .two, y: .two, z: .two), side: .top),
+          ])
+        )
+      ],
+      playedOn: puzzle,
       isValidWord: { _ in false }
     )
 
@@ -89,5 +104,32 @@ class VerificationTests: XCTestCase {
       result,
       nil
     )
+  }
+
+  func testDoubleRemove() {
+    let puzzle = ArchivablePuzzle.mock
+
+    let result = verify(
+      moves: [
+        .init(
+          playedAt: .mock,
+          playerIndex: nil,
+          reactions: nil,
+          score: 0,
+          type: .removedCube(.init(x: .two, y: .two, z: .two))
+        ),
+        .init(
+          playedAt: .mock,
+          playerIndex: nil,
+          reactions: nil,
+          score: 0,
+          type: .removedCube(.init(x: .two, y: .two, z: .two))
+        )
+      ],
+      playedOn: puzzle,
+      isValidWord: { _ in false }
+    )
+
+    XCTAssertNotNil(result)
   }
 }

--- a/Tests/SharedModelsTests/VerificationTests.swift
+++ b/Tests/SharedModelsTests/VerificationTests.swift
@@ -1,13 +1,15 @@
 import XCTest
+
 @testable import SharedModels
 
 class VerificationTests: XCTestCase {
   func testWordLength() {
-    var puzzle = ArchivablePuzzle.mock
+    var puzzle = Puzzle.mock
     puzzle.2.2.2.left.letter = "QU"
     puzzle.2.2.2.right.letter = "A"
 
     let result = verify(
+      moveIndex: 0,
       moves: [
         .init(
           playedAt: .init(),
@@ -20,34 +22,30 @@ class VerificationTests: XCTestCase {
           ])
         )
       ],
-      playedOn: puzzle,
+      playedOn: &puzzle,
       isValidWord: { _ in true }
     )
 
     XCTAssertEqual(
       result,
       .init(
-        totalScore: 10,
-        verifiedMoves: [
-          .init(
-            cubeFaces: [
-              .init(index: .init(x: .two, y: .two, z: .two), side: .left),
-              .init(index: .init(x: .two, y: .two, z: .two), side: .right),
-            ],
-            foundWord: "QUA",
-            score: 10
-          )
-        ]
+        cubeFaces: [
+          .init(index: .init(x: .two, y: .two, z: .two), side: .left),
+          .init(index: .init(x: .two, y: .two, z: .two), side: .right),
+        ],
+        foundWord: "QUA",
+        score: 10
       )
     )
   }
 
   func testDuplicatesNotAllowed() {
-    var puzzle = ArchivablePuzzle.mock
+    var puzzle = Puzzle.mock
     puzzle.2.2.2.left.letter = "T"
     puzzle.2.2.2.right.letter = "O"
 
     let result = verify(
+      moveIndex: 0,
       moves: [
         .init(
           playedAt: .init(),
@@ -61,7 +59,7 @@ class VerificationTests: XCTestCase {
           ])
         )
       ],
-      playedOn: puzzle,
+      playedOn: &puzzle,
       isValidWord: { _ in true }
     )
 
@@ -72,12 +70,13 @@ class VerificationTests: XCTestCase {
   }
 
   func testWordNotInDictionary() {
-    var puzzle = ArchivablePuzzle.mock
+    var puzzle = Puzzle.mock
     puzzle.2.2.2.left.letter = "C"
     puzzle.2.2.2.right.letter = "A"
     puzzle.2.2.2.top.letter = "B"
 
     let result = verify(
+      moveIndex: 0,
       moves: [
         .init(
           playedAt: .init(),
@@ -91,7 +90,7 @@ class VerificationTests: XCTestCase {
           ])
         )
       ],
-      playedOn: puzzle,
+      playedOn: &puzzle,
       isValidWord: { _ in false }
     )
 


### PR DESCRIPTION
If you remove cubes super fast (like you might in timed games) you run the risk of getting two consecutive `.removeCube` moves that are removing the same cube. This is causing some people's games to be rejected by the server.

We will make it so that the client no longer creates those extra remove moves, and we will make the server allow when such consecutive removals are sent.