### PR TITLE
Properly show your/their turn in game tray.

### DIFF
--- a/Sources/ActiveGamesFeature/ActiveGamesView.swift
+++ b/Sources/ActiveGamesFeature/ActiveGamesView.swift
@@ -100,9 +100,7 @@ public struct ActiveGamesView: View {
             : nil
 
           ActiveGameCard(
-            button: self.showMenuItems
-              ? turnBasedButton(match: match)
-              : ActiveGameCardButton(icon: nil, isActive: false, title: Text("Their turn")),
+            button: turnBasedButton(match: match),
             message: turnBasedMessage(match: match),
             tapAction: { self.viewStore.send(.turnBasedGameTapped(match.id), animation: .default) },
             buttonAction: self.showMenuItems


### PR DESCRIPTION
I was able to track down the problem of games in the tray always showing "their turn". This looks like just a simple logic error, but let me know if `showMenuItems` should really be used in this spot.