### PR TITLE
Some Makefile updates for deployment/submission

### DIFF
--- a/Sources/Build/Build.swift
+++ b/Sources/Build/Build.swift
@@ -1,5 +1,4 @@
 import Foundation
-import XCTestDynamicOverlay
 
 public struct Build {
   public var gitSha: () -> String
@@ -22,19 +21,25 @@ public struct Build {
     }
   )
 
-  public static let failing = Self(
-    gitSha: {
-      XCTFail("\(Self.self).gitSha is unimplemented")
-      return ""
-    },
-    number: {
-      XCTFail("\(Self.self).number is unimplemented")
-      return 0
-    }
-  )
-
   public static let noop = Self(
     gitSha: { "deadbeef" },
     number: { 0 }
   )
 }
+
+#if DEBUG
+  import XCTestDynamicOverlay
+
+  extension Build {
+    public static let failing = Self(
+      gitSha: {
+        XCTFail("\(Self.self).gitSha is unimplemented")
+        return ""
+      },
+      number: {
+        XCTFail("\(Self.self).number is unimplemented")
+        return 0
+      }
+    )
+  }
+#endif


### PR DESCRIPTION
Can now do:

```bash
$ make VERSION=1.0 archive-marketing
```

To update the marketing version and archive/commit at once.

Also:

```bash
$ make deploy-server
```

Will not tag/push the commit, e.g., `isowords-staging-deploy-v123`.