### PR TITLE
Make sure `ActivityView` ignores safe areas.

### DIFF
--- a/Sources/GameOverFeature/GameOverView.swift
+++ b/Sources/GameOverFeature/GameOverView.swift
@@ -568,6 +568,7 @@ public struct GameOverView: View {
     )
     .sheet(isPresented: self.$isSharePresented) {
       ActivityView(activityItems: [URL(string: "https://www.isowords.xyz")!])
+        .ignoresSafeArea()
     }
   }
 

--- a/Sources/SettingsFeature/SettingsView.swift
+++ b/Sources/SettingsFeature/SettingsView.swift
@@ -180,6 +180,7 @@ public struct SettingsView: View {
     .alert(self.store.scope(state: \.alert))
     .sheet(isPresented: self.$isSharePresented) {
       ActivityView(activityItems: [URL(string: "https://www.isowords.xyz")!])
+        .ignoresSafeArea()
     }
   }
 }


### PR DESCRIPTION
Back again fixing safe-area-related bugs. 🤣 Here’s how the share sheet’s footer renders without this modifier:

![8A220690-F5B0-4335-83B8-080305A1D25E_4_5005_c](https://user-images.githubusercontent.com/1276296/112411384-33447c80-8cf3-11eb-8cd8-2976a710af11.jpeg)