### PR TITLE
Add 2 second delay to Game Over interactivity

### DIFF
--- a/Sources/GameOverFeature/GameOverView.swift
+++ b/Sources/GameOverFeature/GameOverView.swift
@@ -192,7 +192,6 @@ public let gameOverReducer = Reducer<GameOverState, GameOverAction, GameOverEnvi
 
     switch action {
     case .closeButtonTapped:
-      guard state.isViewEnabled else { return .none }
       guard
         [.notDetermined, .provisional]
           .contains(state.userNotificationSettings?.authorizationStatus),

--- a/Tests/GameOverFeatureTests/GameOverFeatureTests.swift
+++ b/Tests/GameOverFeatureTests/GameOverFeatureTests.swift
@@ -35,8 +35,8 @@ class GameOverFeatureTests: XCTestCase {
         ])
       )
       $0.database.playedGamesCount = { _ in .init(value: 10) }
-      $0.mainRunLoop = RunLoop.immediateScheduler.eraseToAnyScheduler()
       $0.mainQueue = DispatchQueue.immediateScheduler.eraseToAnyScheduler()
+      $0.mainRunLoop = RunLoop.immediateScheduler.eraseToAnyScheduler()
       $0.serverConfig.config = { .init() }
       $0.userNotifications.getNotificationSettings = .none
     }
@@ -59,7 +59,7 @@ class GameOverFeatureTests: XCTestCase {
     )
 
     store.send(.onAppear)
-    store.receive(.enableView)
+    store.receive(.enableView) { $0.isViewEnabled = true }
     store.receive(
       .submitGameResponse(
         .success(
@@ -166,7 +166,7 @@ class GameOverFeatureTests: XCTestCase {
     )
 
     store.send(.onAppear)
-    store.receive(.enableView)
+    store.receive(.enableView) { $0.isViewEnabled = true }
     store.receive(
       .submitGameResponse(
         .success(
@@ -242,7 +242,7 @@ class GameOverFeatureTests: XCTestCase {
     )
 
     store.send(.onAppear)
-    store.receive(.enableView)
+    store.receive(.enableView) { $0.isViewEnabled = true }
     store.receive(.submitGameResponse(.success(.turnBased)))
   }
 
@@ -388,7 +388,7 @@ class GameOverFeatureTests: XCTestCase {
     )
 
     store.send(.onAppear)
-    store.receive(.enableView)
+    store.receive(.enableView) { $0.isViewEnabled = true }
     self.mainRunLoop.advance(by: .seconds(1))
     store.receive(.delayedShowUpgradeInterstitial) {
       $0.upgradeInterstitial = .init()
@@ -436,6 +436,6 @@ class GameOverFeatureTests: XCTestCase {
     )
 
     store.send(.onAppear)
-    store.receive(.enableView)
+    store.receive(.enableView) { $0.isViewEnabled = true }
   }
 }

--- a/Tests/GameOverFeatureTests/GameOverFeatureTests.swift
+++ b/Tests/GameOverFeatureTests/GameOverFeatureTests.swift
@@ -12,7 +12,7 @@ class GameOverFeatureTests: XCTestCase {
   let mainRunLoop = RunLoop.testScheduler
 
   func testSubmitLeaderboardScore() throws {
-    let enviroment = update(GameOverEnvironment.failing) {
+    let environment = update(GameOverEnvironment.failing) {
       $0.audioPlayer = .noop
       $0.apiClient.currentPlayer = { .init(appleReceipt: .mock, player: .blob) }
       $0.apiClient.override(
@@ -55,10 +55,11 @@ class GameOverFeatureTests: XCTestCase {
         isDemo: false
       ),
       reducer: gameOverReducer,
-      environment: enviroment
+      environment: environment
     )
 
     store.send(.onAppear)
+    store.receive(.enableView)
     store.receive(
       .submitGameResponse(
         .success(
@@ -165,6 +166,7 @@ class GameOverFeatureTests: XCTestCase {
     )
 
     store.send(.onAppear)
+    store.receive(.enableView)
     store.receive(
       .submitGameResponse(
         .success(
@@ -184,10 +186,10 @@ class GameOverFeatureTests: XCTestCase {
   }
 
   func testTurnBased_TrackLeaderboards() throws {
-    var enviroment = GameOverEnvironment.failing
-    enviroment.audioPlayer = .noop
-    enviroment.apiClient.currentPlayer = { .init(appleReceipt: .mock, player: .blob) }
-    enviroment.apiClient.override(
+    var environment = GameOverEnvironment.failing
+    environment.audioPlayer = .noop
+    environment.apiClient.currentPlayer = { .init(appleReceipt: .mock, player: .blob) }
+    environment.apiClient.override(
       route: .games(
         .submit(
           .init(
@@ -205,8 +207,8 @@ class GameOverFeatureTests: XCTestCase {
       ),
       withResponse: .ok(["turnBased": true])
     )
-    enviroment.database.playedGamesCount = { _ in .init(value: 10) }
-    enviroment.database.fetchStats = .init(
+    environment.database.playedGamesCount = { _ in .init(value: 10) }
+    environment.database.fetchStats = .init(
       value: .init(
         averageWordLength: nil,
         gamesPlayed: 1,
@@ -216,10 +218,10 @@ class GameOverFeatureTests: XCTestCase {
         wordsFound: 1
       )
     )
-    enviroment.mainRunLoop = RunLoop.immediateScheduler.eraseToAnyScheduler()
-    enviroment.mainQueue = DispatchQueue.immediateScheduler.eraseToAnyScheduler()
-    enviroment.serverConfig.config = { .init() }
-    enviroment.userNotifications.getNotificationSettings = .none
+    environment.mainRunLoop = RunLoop.immediateScheduler.eraseToAnyScheduler()
+    environment.mainQueue = DispatchQueue.immediateScheduler.eraseToAnyScheduler()
+    environment.serverConfig.config = { .init() }
+    environment.userNotifications.getNotificationSettings = .none
 
     let store = TestStore(
       initialState: GameOverState(
@@ -236,10 +238,11 @@ class GameOverFeatureTests: XCTestCase {
         isDemo: false
       ),
       reducer: gameOverReducer,
-      environment: enviroment
+      environment: environment
     )
 
     store.send(.onAppear)
+    store.receive(.enableView)
     store.receive(.submitGameResponse(.success(.turnBased)))
   }
 
@@ -284,7 +287,7 @@ class GameOverFeatureTests: XCTestCase {
     environment.userNotifications.getNotificationSettings = .none
 
     let store = TestStore(
-      initialState: GameOverState(completedGame: completedGame, isDemo: false),
+      initialState: GameOverState(completedGame: completedGame, isDemo: false, isViewEnabled: true),
       reducer: gameOverReducer,
       environment: environment
     )
@@ -385,6 +388,7 @@ class GameOverFeatureTests: XCTestCase {
     )
 
     store.send(.onAppear)
+    store.receive(.enableView)
     self.mainRunLoop.advance(by: .seconds(1))
     store.receive(.delayedShowUpgradeInterstitial) {
       $0.upgradeInterstitial = .init()
@@ -432,5 +436,6 @@ class GameOverFeatureTests: XCTestCase {
     )
 
     store.send(.onAppear)
+    store.receive(.enableView)
   }
 }


### PR DESCRIPTION
When racing the clock in timed games it is a bit too easy to launch right into a new game if you were trying to enter a final word. This PR adds a short delay to enabling the Game Over view to prevent this.