### PR TITLE
Remove unneeded effect modifiers

### DIFF
--- a/Sources/AppFeature/GameCenterCore.swift
+++ b/Sources/AppFeature/GameCenterCore.swift
@@ -180,9 +180,6 @@ extension Reducer where State == AppState, Action == AppAction, Environment == A
                     "\(environment.gameCenter.localPlayer.localPlayer().displayName) forfeited the match."
                 )
               )
-              .catchToEffect()
-              .ignoreOutput()
-              .eraseToEffect()
               .fireAndForget()
 
           case .gameCenter(.listener):


### PR DESCRIPTION
The `endMatchInTurn`  closure already produces an
effect. Which to my understanding means there is no need to
`catchToEffect` anymore, making that a useless noop.
Furthermore, if we `fireAndForget`, then ignoring any
output and errors is already implied and again, the call
to `ignoreOutput` is just noise. As with the above
`eraseToEffect` was a noop from the beginning
since everything is already an effect.

⚠️ 
This is just my understanding from watching the pointfree
videos and reading the codebase. I have _intentionally_ not
run the test-suite to see if, in case my understanding is wrong_,
the test suite catches this haha