### PR TITLE
Move `ServerRoute` to `SharedModels`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,6 @@ var package = Package(
     .library(name: "PuzzleGen", targets: ["PuzzleGen"]),
     .library(name: "ServerConfig", targets: ["ServerConfig"]),
     .library(name: "ServerRouter", targets: ["ServerRouter"]),
-    .library(name: "ServerRoutes", targets: ["ServerRoutes"]),
     .library(name: "SharedModels", targets: ["SharedModels"]),
     .library(name: "Sqlite", targets: ["Sqlite"]),
     .library(name: "TestHelpers", targets: ["TestHelpers"]),
@@ -104,16 +103,9 @@ var package = Package(
     .target(
       name: "ServerRouter",
       dependencies: [
-        "ServerRoutes",
         "SharedModels",
         .product(name: "ApplicativeRouter", package: "Web"),
         .product(name: "Tagged", package: "swift-tagged"),
-      ]
-    ),
-    .target(
-      name: "ServerRoutes",
-      dependencies: [
-        "SharedModels"
       ]
     ),
     .testTarget(
@@ -242,7 +234,6 @@ if ProcessInfo.processInfo.environment["TEST_SERVER"] == nil {
     .target(
       name: "ApiClient",
       dependencies: [
-        "ServerRoutes",
         "SharedModels",
         "XCTestDebugSupport",
         .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
@@ -1106,7 +1097,6 @@ package.targets.append(contentsOf: [
     dependencies: [
       "DatabaseClient",
       "MiddlewareHelpers",
-      "ServerRoutes",
       "SharedModels",
       .product(name: "HttpPipeline", package: "Web"),
     ]

--- a/Sources/ApiClient/Client.swift
+++ b/Sources/ApiClient/Client.swift
@@ -1,7 +1,6 @@
 import Combine
 import ComposableArchitecture
 import Foundation
-@_exported import ServerRoutes
 import SharedModels
 
 public struct ApiClient {

--- a/Sources/DemoMiddleware/DemoMiddleware.swift
+++ b/Sources/DemoMiddleware/DemoMiddleware.swift
@@ -3,7 +3,6 @@ import DictionaryClient
 import Either
 import HttpPipeline
 import Prelude
-import ServerRoutes
 import SharedModels
 
 public struct SubmitDemoGameRequest {

--- a/Sources/LeaderboardMiddleware/SubmitGameMiddleware.swift
+++ b/Sources/LeaderboardMiddleware/SubmitGameMiddleware.swift
@@ -5,7 +5,6 @@ import Foundation
 import HttpPipeline
 import Prelude
 import ServerRouter
-import ServerRoutes
 import SharedModels
 
 public struct SubmitGameRequest {

--- a/Sources/PushMiddleware/PushSettingMiddleware.swift
+++ b/Sources/PushMiddleware/PushSettingMiddleware.swift
@@ -2,7 +2,6 @@ import DatabaseClient
 import Either
 import HttpPipeline
 import Prelude
-import ServerRoutes
 import SharedModels
 
 public struct UpdatePushSettingRequest {

--- a/Sources/ServerRouter/Router.swift
+++ b/Sources/ServerRouter/Router.swift
@@ -1,7 +1,6 @@
 import ApplicativeRouter
 import Foundation
 import Prelude
-import ServerRoutes
 import SharedModels
 import Tagged
 

--- a/Sources/ShareGameMiddleware/ShareGameMiddleware.swift
+++ b/Sources/ShareGameMiddleware/ShareGameMiddleware.swift
@@ -6,7 +6,6 @@ import Foundation
 import HttpPipeline
 import Prelude
 import ServerRouter
-import ServerRoutes
 import SharedModels
 
 public struct ShareGameRequest {

--- a/Sources/SharedModels/API/ServerRoute.swift
+++ b/Sources/SharedModels/API/ServerRoute.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SharedModels
 import Tagged
 
 public enum ServerRoute: Equatable {
@@ -327,15 +326,5 @@ public enum ServerRoute: Equatable {
 
   public enum SharedGame: Equatable {
     case show(SharedModels.SharedGame.Code)
-  }
-}
-
-extension Dictionary {
-  func transformKeys<NewKey>(_ f: (Key) -> NewKey) -> [NewKey: Value] {
-    var result: [NewKey: Value] = [:]
-    for (key, value) in self {
-      result[f(key)] = value
-    }
-    return result
   }
 }

--- a/Sources/SharedModels/CompletedGame.swift
+++ b/Sources/SharedModels/CompletedGame.swift
@@ -143,13 +143,3 @@ public struct CompletedGame: Codable, Equatable {
     self.moves.reduce(into: 0) { $0 += $1.score }
   }
 }
-
-extension Dictionary {
-  func transformKeys<NewKey>(_ f: (Key) -> NewKey) -> [NewKey: Value] {
-    var result: [NewKey: Value] = [:]
-    for (key, value) in self {
-      result[f(key)] = value
-    }
-    return result
-  }
-}

--- a/Sources/SharedModels/Internal/TransformKeys.swift
+++ b/Sources/SharedModels/Internal/TransformKeys.swift
@@ -1,0 +1,10 @@
+
+extension Dictionary {
+  func transformKeys<NewKey>(_ f: (Key) -> NewKey) -> [NewKey: Value] {
+    var result: [NewKey: Value] = [:]
+    for (key, value) in self {
+      result[f(key)] = value
+    }
+    return result
+  }
+}

--- a/Sources/SiteMiddleware/ApiMiddleware.swift
+++ b/Sources/SiteMiddleware/ApiMiddleware.swift
@@ -14,7 +14,6 @@ import Prelude
 import PushMiddleware
 import ServerConfigMiddleware
 import ServerRouter
-import ServerRoutes
 import ShareGameMiddleware
 import SharedModels
 import SnsClient

--- a/Sources/SiteMiddleware/Environment.swift
+++ b/Sources/SiteMiddleware/Environment.swift
@@ -6,7 +6,6 @@ import Foundation
 import MailgunClient
 import Overture
 import ServerRouter
-import ServerRoutes
 import SharedModels
 import SnsClient
 import VerifyReceiptMiddleware

--- a/Sources/SiteMiddleware/SiteMiddleware.swift
+++ b/Sources/SiteMiddleware/SiteMiddleware.swift
@@ -7,7 +7,6 @@ import MiddlewareHelpers
 import Prelude
 import ServerConfig
 import ServerRouter
-import ServerRoutes
 import ShareGameMiddleware
 import Tagged
 

--- a/Sources/SiteMiddleware/SiteMiddleware.swift
+++ b/Sources/SiteMiddleware/SiteMiddleware.swift
@@ -7,6 +7,7 @@ import MiddlewareHelpers
 import Prelude
 import ServerConfig
 import ServerRouter
+import SharedModels
 import ShareGameMiddleware
 import Tagged
 

--- a/Tests/DailyChallengeMiddlewareTests/DailyChallengeMiddlewareTests.swift
+++ b/Tests/DailyChallengeMiddlewareTests/DailyChallengeMiddlewareTests.swift
@@ -382,7 +382,7 @@ class DailyChallengeMiddlewareTests: XCTestCase {
       _assertInlineSnapshot(matching: result, as: .conn, with: #"""
         POST /api/games?accessToken=deadbeef-dead-beef-dead-beefdeadbeef&timestamp=1234567890
         X-Signature: ewogICJnYW1lQ29udGV4dCIgOiB7CiAgICAiZGFpbHlDaGFsbGVuZ2VJZCIgOiAiREVBREJFRUYtREVBRC1CRUVGLURFQUQtREExMTdDNEExMTMyIgogIH0sCiAgIm1vdmVzIiA6IFsKICAgIHsKICAgICAgInBsYXllZEF0IiA6IDEyMzQ1Njc4OTAsCiAgICAgICJzY29yZSIgOiAxMDAwLAogICAgICAidHlwZSIgOiB7CiAgICAgICAgInBsYXllZFdvcmQiIDogWwogICAgICAgICAgewogICAgICAgICAgICAiaW5kZXgiIDogewogICAgICAgICAgICAgICJ4IiA6IDAsCiAgICAgICAgICAgICAgInkiIDogMCwKICAgICAgICAgICAgICAieiIgOiAwCiAgICAgICAgICAgIH0sCiAgICAgICAgICAgICJzaWRlIiA6IDEKICAgICAgICAgIH0sCiAgICAgICAgICB7CiAgICAgICAgICAgICJpbmRleCIgOiB7CiAgICAgICAgICAgICAgIngiIDogMCwKICAgICAgICAgICAgICAieSIgOiAwLAogICAgICAgICAgICAgICJ6IiA6IDAKICAgICAgICAgICAgfSwKICAgICAgICAgICAgInNpZGUiIDogMgogICAgICAgICAgfSwKICAgICAgICAgIHsKICAgICAgICAgICAgImluZGV4IiA6IHsKICAgICAgICAgICAgICAieCIgOiAxLAogICAgICAgICAgICAgICJ5IiA6IDAsCiAgICAgICAgICAgICAgInoiIDogMAogICAgICAgICAgICB9LAogICAgICAgICAgICAic2lkZSIgOiAyCiAgICAgICAgICB9CiAgICAgICAgXQogICAgICB9CiAgICB9CiAgXQp9LS0tLVNFQ1JFVF9ERUFEQkVFRi0tLS0xMjM0NTY3ODkw
-
+        
         {
           "gameContext" : {
             "dailyChallengeId" : "DEADBEEF-DEAD-BEEF-DEAD-DA117C4A1132"
@@ -422,7 +422,7 @@ class DailyChallengeMiddlewareTests: XCTestCase {
             }
           ]
         }
-
+        
         400 Bad Request
         Content-Length: 492
         Content-Type: application/json
@@ -432,11 +432,11 @@ class DailyChallengeMiddlewareTests: XCTestCase {
         X-Frame-Options: SAMEORIGIN
         X-Permitted-Cross-Domain-Policies: none
         X-XSS-Protection: 1; mode=block
-
+        
         {
-          "errorDump" : "▿ SharedModels.ApiError\n  - errorDump: \"- LeaderboardMiddleware.VerificationFailed\\n\"\n  - file: \"LeaderboardMiddleware\/SubmitGameMiddleware.swift\"\n  - line: 110\n  - message: \"The operation couldn’t be completed. (LeaderboardMiddleware.VerificationFailed error 1.)\"\n",
+          "errorDump" : "▿ SharedModels.ApiError\n  - errorDump: \"- LeaderboardMiddleware.VerificationFailed\\n\"\n  - file: \"LeaderboardMiddleware\/SubmitGameMiddleware.swift\"\n  - line: 109\n  - message: \"The operation couldn’t be completed. (LeaderboardMiddleware.VerificationFailed error 1.)\"\n",
           "file" : "LeaderboardMiddleware\/SubmitGameMiddleware.swift",
-          "line" : 203,
+          "line" : 202,
           "message" : "The operation couldn’t be completed. (LeaderboardMiddleware.VerificationFailed error 1.)"
         }
         """#

--- a/Tests/DailyChallengeMiddlewareTests/DailyChallengeMiddlewareTests.swift
+++ b/Tests/DailyChallengeMiddlewareTests/DailyChallengeMiddlewareTests.swift
@@ -9,7 +9,6 @@ import HttpPipeline
 import HttpPipelineTestSupport
 import MailgunClient
 import Overture
-import ServerRoutes
 import SharedModels
 import SnapshotTesting
 import XCTest

--- a/Tests/DemoMiddlewareTests/DemoMiddlewareTests.swift
+++ b/Tests/DemoMiddlewareTests/DemoMiddlewareTests.swift
@@ -10,7 +10,6 @@ import HttpPipelineTestSupport
 import Overture
 import Prelude
 import ServerRouter
-import ServerRoutes
 import SharedModels
 import SiteMiddleware
 import SnapshotTesting

--- a/Tests/LeaderboardMiddlewareIntegrationTests/LeaderboardMiddlewareIntegrationTests.swift
+++ b/Tests/LeaderboardMiddlewareIntegrationTests/LeaderboardMiddlewareIntegrationTests.swift
@@ -13,7 +13,6 @@ import Overture
 import PostgresKit
 import Prelude
 import ServerRouter
-import ServerRoutes
 import SharedModels
 import SiteMiddleware
 import SnapshotTesting

--- a/Tests/LeaderboardMiddlewareTests/LeaderboardMiddlewareTests.swift
+++ b/Tests/LeaderboardMiddlewareTests/LeaderboardMiddlewareTests.swift
@@ -10,7 +10,6 @@ import HttpPipelineTestSupport
 import Overture
 import Prelude
 import ServerRouter
-import ServerRoutes
 import SharedModels
 import SnapshotTesting
 import XCTest

--- a/Tests/PushMiddlewareTests/PushMiddlewareTests.swift
+++ b/Tests/PushMiddlewareTests/PushMiddlewareTests.swift
@@ -10,7 +10,6 @@ import Overture
 import Prelude
 import PushMiddleware
 import ServerRouter
-import ServerRoutes
 import SharedModels
 import SiteMiddleware
 import SnapshotTesting

--- a/Tests/ServerRouterTests/ConfigTests.swift
+++ b/Tests/ServerRouterTests/ConfigTests.swift
@@ -4,7 +4,6 @@ import Foundation
   import FoundationNetworking
 #endif
 import Overture
-import ServerRoutes
 import SharedModels
 import TestHelpers
 import XCTest

--- a/Tests/ServerRouterTests/ServerRouterTests.swift
+++ b/Tests/ServerRouterTests/ServerRouterTests.swift
@@ -4,7 +4,6 @@ import Foundation
   import FoundationNetworking
 #endif
 import Overture
-import ServerRoutes
 import SharedModels
 import TestHelpers
 import XCTest


### PR DESCRIPTION
Because it's really a shared model in its own right, it doesn't need to live in its own module.