### PR TITLE
Don't clear out saved game when multiplayer game ends

### DIFF
--- a/Sources/AppFeature/AppView.swift
+++ b/Sources/AppFeature/AppView.swift
@@ -294,13 +294,13 @@ let appReducerCore = Reducer<AppState, AppAction, AppEnvironment> { state, actio
   case .currentGame(.game(.endGameButtonTapped)),
     .currentGame(.game(.gameOver(.onAppear))):
 
-    guard let game = state.game, game.gameMode == .unlimited
-    else { return .none }
-
-    if game.isDailyChallenge {
+    switch (state.game?.gameContext, state.game?.gameMode) {
+    case (.dailyChallenge, .unlimited):
       state.home.savedGames.dailyChallengeUnlimited = nil
-    } else {
+    case (.solo, .unlimited):
       state.home.savedGames.unlimited = nil
+    default:
+      break
     }
     return .none
 


### PR DESCRIPTION
Surprised we didn't noticed this earlier, though I guess we play way more dailies and multiplayer than casual solo.