### PR TITLE
Fix query to properly count 'outOf'

### DIFF
--- a/Sources/DatabaseLive/DatabaseLive.swift
+++ b/Sources/DatabaseLive/DatabaseLive.swift
@@ -191,7 +191,7 @@ extension DatabaseClient {
             WHERE "leaderboardScores"."dailyChallengeId" = \(bind: request.dailyChallengeId)
           ),
           "filteredDailyChallengeScoresCount" AS (
-            SELECT count(DISTINCT "score") AS "outOf"
+            SELECT count("playerId") AS "outOf"
             FROM "filteredDailyChallengeScores"
           ),
           "playerDailyChallengeResult" AS (
@@ -238,7 +238,7 @@ extension DatabaseClient {
             AND "dailyChallenges"."language" = \(bind: request.language)
           ),
           "rankedChallengeResultsCount" AS (
-            SELECT count(DISTINCT "score") AS "outOf"
+            SELECT count("playerId") AS "outOf"
             FROM "rankedChallengeResults"
           )
           SELECT

--- a/Tests/DatabaseLiveTests/DatabaseLiveTests.swift
+++ b/Tests/DatabaseLiveTests/DatabaseLiveTests.swift
@@ -418,10 +418,10 @@ class DatabaseLiveTests: DatabaseTestCase {
     XCTAssertEqual(
       results,
       [
-        .init(outOf: 3, rank: 3, score: 1_000),
-        .init(outOf: 3, rank: 2, score: 2_000),
-        .init(outOf: 3, rank: 1, score: 3_000),
-        .init(outOf: 3, rank: 2, score: 2_000),
+        .init(outOf: 4, rank: 3, score: 1_000),
+        .init(outOf: 4, rank: 2, score: 2_000),
+        .init(outOf: 4, rank: 1, score: 3_000),
+        .init(outOf: 4, rank: 2, score: 2_000),
       ]
     )
   }


### PR DESCRIPTION
We were accidentally undercounting daily challenge results because we weren't counting tied scores 😬