### PR TITLE
Better handling around no purchases and restore errors.

### DIFF
--- a/Sources/ComposableStoreKit/Client.swift
+++ b/Sources/ComposableStoreKit/Client.swift
@@ -15,7 +15,7 @@ public struct StoreKitClient {
   public enum PaymentTransactionObserverEvent: Equatable {
     case removedTransactions([PaymentTransaction])
     case restoreCompletedTransactionsFailed(NSError)
-    case restoreCompletedTransactionsFinished
+    case restoreCompletedTransactionsFinished(transactionCount: Int)
     case updatedTransactions([PaymentTransaction])
   }
 

--- a/Sources/ComposableStoreKit/Client.swift
+++ b/Sources/ComposableStoreKit/Client.swift
@@ -15,7 +15,7 @@ public struct StoreKitClient {
   public enum PaymentTransactionObserverEvent: Equatable {
     case removedTransactions([PaymentTransaction])
     case restoreCompletedTransactionsFailed(NSError)
-    case restoreCompletedTransactionsFinished(transactionCount: Int)
+    case restoreCompletedTransactionsFinished(transactions: [PaymentTransaction])
     case updatedTransactions([PaymentTransaction])
   }
 

--- a/Sources/ComposableStoreKit/Live.swift
+++ b/Sources/ComposableStoreKit/Live.swift
@@ -113,7 +113,11 @@ private class Observer: NSObject, SKPaymentTransactionObserver {
   }
 
   func paymentQueueRestoreCompletedTransactionsFinished(_ queue: SKPaymentQueue) {
-    self.subscriber.send(.restoreCompletedTransactionsFinished(transactionCount: queue.transactions.count))
+    self.subscriber.send(
+      .restoreCompletedTransactionsFinished(
+        transactions: queue.transactions.map(StoreKitClient.PaymentTransaction.init)
+      )
+    )
   }
 
   func paymentQueue(

--- a/Sources/ComposableStoreKit/Live.swift
+++ b/Sources/ComposableStoreKit/Live.swift
@@ -113,7 +113,7 @@ private class Observer: NSObject, SKPaymentTransactionObserver {
   }
 
   func paymentQueueRestoreCompletedTransactionsFinished(_ queue: SKPaymentQueue) {
-    self.subscriber.send(.restoreCompletedTransactionsFinished)
+    self.subscriber.send(.restoreCompletedTransactionsFinished(transactionCount: queue.transactions.count))
   }
 
   func paymentQueue(

--- a/Sources/SettingsFeature/Settings.swift
+++ b/Sources/SettingsFeature/Settings.swift
@@ -497,9 +497,9 @@ public let settingsReducer = Reducer<SettingsState, SettingsAction, SettingsEnvi
         .catchToEffect()
         .map(SettingsAction.currentPlayerRefreshed)
 
-    case let .paymentTransaction(.restoreCompletedTransactionsFinished(transactionCount)):
+    case let .paymentTransaction(.restoreCompletedTransactionsFinished(transactions)):
       state.isRestoring = false
-      state.alert = transactionCount == 0 ? .noRestoredPurchases : nil
+      state.alert = transactions.isEmpty ? .noRestoredPurchases : nil
       return .none
 
     case .paymentTransaction(.restoreCompletedTransactionsFailed):

--- a/Sources/SettingsFeature/Settings.swift
+++ b/Sources/SettingsFeature/Settings.swift
@@ -497,6 +497,16 @@ public let settingsReducer = Reducer<SettingsState, SettingsAction, SettingsEnvi
         .catchToEffect()
         .map(SettingsAction.currentPlayerRefreshed)
 
+    case let .paymentTransaction(.restoreCompletedTransactionsFinished(transactionCount)):
+      state.isRestoring = false
+      state.alert = transactionCount == 0 ? .noRestoredPurchases : nil
+      return .none
+
+    case .paymentTransaction(.restoreCompletedTransactionsFailed):
+      state.isRestoring = false
+      state.alert = .restoredPurchasesFailed
+      return .none
+
     case .paymentTransaction:
       return .none
 
@@ -594,6 +604,28 @@ extension AlertState where Action == SettingsAction {
       """),
     primaryButton: .default(.init("Ok"), send: .binding(.set(\.alert, nil))),
     secondaryButton: .default(.init("Open Settings"), send: .openSettingButtonTapped),
+    onDismiss: .binding(.set(\.alert, nil))
+  )
+
+  static let restoredPurchasesFailed = Self(
+    title: .init("Error"),
+    message: .init(
+      """
+      We couldn’t restore purchases, please try again.
+      """),
+    primaryButton: .default(.init("Ok"), send: .binding(.set(\.alert, nil))),
+    secondaryButton: nil,
+    onDismiss: .binding(.set(\.alert, nil))
+  )
+
+  static let noRestoredPurchases = Self(
+    title: .init("No Purchases"),
+    message: .init(
+      """
+      No purchases were found to restore.
+      """),
+    primaryButton: .default(.init("Ok"), send: .binding(.set(\.alert, nil))),
+    secondaryButton: nil,
     onDismiss: .binding(.set(\.alert, nil))
   )
 }

--- a/Tests/SettingsFeatureTests/SettingsPurchaseTests.swift
+++ b/Tests/SettingsFeatureTests/SettingsPurchaseTests.swift
@@ -121,7 +121,7 @@ class SettingsPurchaseTests: XCTestCase {
     XCTAssertEqual(didRestoreCompletedTransactions, true)
     storeKitObserver.send(.updatedTransactions([.restored]))
     storeKitObserver.send(.removedTransactions([.restored]))
-    storeKitObserver.send(.restoreCompletedTransactionsFinished)
+    storeKitObserver.send(.restoreCompletedTransactionsFinished(transactionCount: 1))
 
     store.receive(SettingsAction.paymentTransaction(.updatedTransactions([.restored])))
     store.receive(SettingsAction.paymentTransaction(.removedTransactions([.restored])))
@@ -129,7 +129,113 @@ class SettingsPurchaseTests: XCTestCase {
       $0.isRestoring = false
       $0.fullGamePurchasedAt = .mock
     }
-    store.receive(SettingsAction.paymentTransaction(.restoreCompletedTransactionsFinished))
+    store.receive(SettingsAction.paymentTransaction(.restoreCompletedTransactionsFinished(transactionCount: 1)))
+    store.send(.onDismiss)
+  }
+
+  func testRestore_NoPurchasesPath() throws {
+    var didRestoreCompletedTransactions = false
+    let storeKitObserver = PassthroughSubject<
+      StoreKitClient.PaymentTransactionObserverEvent, Never
+    >()
+
+    var environment = self.defaultEnvironment
+    environment.serverConfig.config = {
+      .init(productIdentifiers: .init(fullGame: "xyz.isowords.full_game"))
+    }
+    environment.apiClient.currentPlayer = { .some(.blobWithoutPurchase) }
+    environment.apiClient.refreshCurrentPlayer = { .init(value: .blobWithoutPurchase) }
+    environment.storeKit.restoreCompletedTransactions = {
+      .fireAndForget {
+        didRestoreCompletedTransactions = true
+      }
+    }
+    environment.storeKit.fetchProducts = { _ in
+      .init(value: .init(invalidProductIdentifiers: [], products: [.fullGame]))
+    }
+    environment.storeKit.observer = storeKitObserver.eraseToEffect()
+
+    let store = TestStore(
+      initialState: SettingsState(),
+      reducer: settingsReducer,
+      environment: environment
+    )
+
+    store.send(.onAppear) {
+      $0.buildNumber = 42
+      $0.developer.currentBaseUrl = .localhost
+    }
+    store.receive(
+      .productsResponse(.success(.init(invalidProductIdentifiers: [], products: [.fullGame])))
+    ) {
+      $0.fullGameProduct = .success(.fullGame)
+    }
+    store.send(.restoreButtonTapped) {
+      $0.isRestoring = true
+    }
+
+    XCTAssertEqual(didRestoreCompletedTransactions, true)
+    storeKitObserver.send(.restoreCompletedTransactionsFinished(transactionCount: 0))
+
+    store.receive(SettingsAction.paymentTransaction(.restoreCompletedTransactionsFinished(transactionCount: 0))) {
+      $0.isRestoring = false
+      $0.alert = .noRestoredPurchases
+    }
+
+    store.send(.onDismiss)
+  }
+
+  func testRestore_ErrorPath() throws {
+    var didRestoreCompletedTransactions = false
+    let storeKitObserver = PassthroughSubject<
+      StoreKitClient.PaymentTransactionObserverEvent, Never
+    >()
+
+    var environment = self.defaultEnvironment
+    environment.serverConfig.config = {
+      .init(productIdentifiers: .init(fullGame: "xyz.isowords.full_game"))
+    }
+    environment.apiClient.currentPlayer = { .some(.blobWithoutPurchase) }
+    environment.apiClient.refreshCurrentPlayer = { .init(value: .blobWithoutPurchase) }
+    environment.storeKit.restoreCompletedTransactions = {
+      .fireAndForget {
+        didRestoreCompletedTransactions = true
+      }
+    }
+    environment.storeKit.fetchProducts = { _ in
+      .init(value: .init(invalidProductIdentifiers: [], products: [.fullGame]))
+    }
+    environment.storeKit.observer = storeKitObserver.eraseToEffect()
+
+    let store = TestStore(
+      initialState: SettingsState(),
+      reducer: settingsReducer,
+      environment: environment
+    )
+
+    store.send(.onAppear) {
+      $0.buildNumber = 42
+      $0.developer.currentBaseUrl = .localhost
+    }
+    store.receive(
+      .productsResponse(.success(.init(invalidProductIdentifiers: [], products: [.fullGame])))
+    ) {
+      $0.fullGameProduct = .success(.fullGame)
+    }
+    store.send(.restoreButtonTapped) {
+      $0.isRestoring = true
+    }
+
+    XCTAssertEqual(didRestoreCompletedTransactions, true)
+
+    let restoreCompletedTransactionsError = NSError(domain: "", code: 1)
+    storeKitObserver.send(.restoreCompletedTransactionsFailed(restoreCompletedTransactionsError))
+
+    store.receive(SettingsAction.paymentTransaction(.restoreCompletedTransactionsFailed(restoreCompletedTransactionsError))) {
+      $0.isRestoring = false
+      $0.alert = .restoredPurchasesFailed
+    }
+
     store.send(.onDismiss)
   }
 }

--- a/Tests/SettingsFeatureTests/SettingsPurchaseTests.swift
+++ b/Tests/SettingsFeatureTests/SettingsPurchaseTests.swift
@@ -121,7 +121,7 @@ class SettingsPurchaseTests: XCTestCase {
     XCTAssertEqual(didRestoreCompletedTransactions, true)
     storeKitObserver.send(.updatedTransactions([.restored]))
     storeKitObserver.send(.removedTransactions([.restored]))
-    storeKitObserver.send(.restoreCompletedTransactionsFinished(transactionCount: 1))
+    storeKitObserver.send(.restoreCompletedTransactionsFinished(transactions: [.restored]))
 
     store.receive(SettingsAction.paymentTransaction(.updatedTransactions([.restored])))
     store.receive(SettingsAction.paymentTransaction(.removedTransactions([.restored])))
@@ -129,7 +129,7 @@ class SettingsPurchaseTests: XCTestCase {
       $0.isRestoring = false
       $0.fullGamePurchasedAt = .mock
     }
-    store.receive(SettingsAction.paymentTransaction(.restoreCompletedTransactionsFinished(transactionCount: 1)))
+    store.receive(SettingsAction.paymentTransaction(.restoreCompletedTransactionsFinished(transactions: [.restored])))
     store.send(.onDismiss)
   }
 
@@ -175,9 +175,9 @@ class SettingsPurchaseTests: XCTestCase {
     }
 
     XCTAssertEqual(didRestoreCompletedTransactions, true)
-    storeKitObserver.send(.restoreCompletedTransactionsFinished(transactionCount: 0))
+    storeKitObserver.send(.restoreCompletedTransactionsFinished(transactions: []))
 
-    store.receive(SettingsAction.paymentTransaction(.restoreCompletedTransactionsFinished(transactionCount: 0))) {
+    store.receive(SettingsAction.paymentTransaction(.restoreCompletedTransactionsFinished(transactions: []))) {
       $0.isRestoring = false
       $0.alert = .noRestoredPurchases
     }


### PR DESCRIPTION
Noticed the restore purchases flow would hang when none have been made (video below). Thiiink this diff. should cover that case and adds some messaging around restoration errors. I tried my best to test on-device, but I’d double check with sandbox App Store Connect accounts on y’all’s end. ✅

https://user-images.githubusercontent.com/1276296/114288637-d14c7c80-9a3f-11eb-9aa9-e807ad270f1d.mp4