### PR TITLE
Add operator to defer starting an effect.

### DIFF
--- a/Sources/GameCore/GameCore.swift
+++ b/Sources/GameCore/GameCore.swift
@@ -25,6 +25,7 @@ import RemoteNotificationsClient
 import ServerConfigClient
 import SharedModels
 import SwiftUI
+import TcaHelpers
 import UIApplicationClient
 import UpgradeInterstitialFeature
 import UserDefaultsClient
@@ -713,8 +714,7 @@ extension GameState {
           .map { index in
             environment.audioPlayer
               .play(.cubeRemove)
-              .debounce(
-                id: index,
+              .deferred(
                 for: .milliseconds(removeCubeDelay(index: index)),
                 scheduler: environment.mainQueue
               )

--- a/Sources/TcaHelpers/Deferring.swift
+++ b/Sources/TcaHelpers/Deferring.swift
@@ -1,0 +1,16 @@
+import ComposableArchitecture
+import Combine
+
+extension Effect {
+  public func deferred<S: Scheduler>(
+    for dueTime: S.SchedulerTimeType.Stride,
+    scheduler: S,
+    options: S.SchedulerOptions? = nil
+  ) -> Effect {
+    Just(())
+      .setFailureType(to: Failure.self)
+      .delay(for: dueTime, scheduler: scheduler, options: options)
+      .flatMap { self }
+      .eraseToEffect()
+  }
+}


### PR DESCRIPTION
We've talked about add this to TCA proper so let's try it out a bit in isowords. This is especially use for fire-and-forget effects that you want to delay when they start. You can't use the `.delay` operator on those effects because that only delays _emissions_, not when the effect _starts_.