### PR TITLE
Remove matching helper now that swift-case-paths has it.

### DIFF
--- a/Sources/TcaHelpers/CasePathMatching.swift
+++ b/Sources/TcaHelpers/CasePathMatching.swift
@@ -1,9 +1,5 @@
 import CasePaths
 
-public func ~= <Root, Value>(pattern: CasePath<Root, Value>, value: Root) -> Bool {
-  pattern.extract(from: value) != nil
-}
-
 extension CasePath {
   public func isMatching(_ value: Root) -> Bool {
     self.extract(from: value) != nil


### PR DESCRIPTION
This is causing ambiguity problems on `main`.