### PR TITLE
Restores onboarding while also allowing for the Daily Challenge quick action.

### DIFF
--- a/App/iOS/App.swift
+++ b/App/iOS/App.swift
@@ -56,19 +56,20 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
         sessionRole: connectingSceneSession.role
       )
     ) {
+      SceneDelegate.appDelegate = self
       $0.delegateClass = SceneDelegate.self
     }
   }
 
-  final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+  private final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    static fileprivate(set) weak var appDelegate: AppDelegate?
 
     func windowScene(
       _ windowScene: UIWindowScene,
       performActionFor shortcutItem: UIApplicationShortcutItem,
       completionHandler: @escaping (Bool) -> Void
     ) {
-      self.appDelegate.viewStore.send(
+      Self.appDelegate?.viewStore.send(
         .appDelegate(.scene(.quickAction(type: shortcutItem.type)))
       )
     }

--- a/App/iOS/Info.plist
+++ b/App/iOS/Info.plist
@@ -230,5 +230,16 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIApplicationShortcutItems</key>
+	<array>
+		<dict>
+			<key>UIApplicationShortcutItemType</key>
+			<string>dailyChallenge</string>
+			<key>UIApplicationShortcutItemIconType</key>
+			<string>UIApplicationShortcutIconTypeDate</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>Daily Challenge</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/Sources/AppFeature/AppDelegate.swift
+++ b/Sources/AppFeature/AppDelegate.swift
@@ -13,8 +13,13 @@ import UIKit
 import UserNotifications
 
 public enum AppDelegateAction: Equatable {
+  public enum SceneAction: Equatable {
+    case quickAction(type: String)
+  }
+
   case didFinishLaunching
   case didRegisterForRemoteNotifications(Result<Data, NSError>)
+  case scene(SceneAction)
   case userNotifications(UserNotificationClient.DelegateEvent)
   case userSettingsLoaded(Result<UserSettings, NSError>)
 }
@@ -144,5 +149,7 @@ let appDelegateReducer = Reducer<
         .subscribe(on: environment.mainQueue)
         .fireAndForget()
     )
+  case .scene:
+    return .none
   }
 }

--- a/Sources/AppFeature/AppView.swift
+++ b/Sources/AppFeature/AppView.swift
@@ -260,6 +260,18 @@ let appReducerCore = Reducer<AppState, AppAction, AppEnvironment> { state, actio
 
     return effect
 
+  case let .appDelegate(.scene(.quickAction(type: type))):
+    enum QuickAction: String {
+      case dailyChallenge
+    }
+
+    switch QuickAction(rawValue: type) {
+    case .dailyChallenge:
+      return Effect(value: .home(.setNavigation(tag: .dailyChallenge)))
+    case .none:
+      return .none  // No-op on unknown Quick Actions.
+    }
+
   case .appDelegate:
     return .none
 

--- a/Tests/AppFeatureTests/QuickActionTests.swift
+++ b/Tests/AppFeatureTests/QuickActionTests.swift
@@ -1,0 +1,31 @@
+import ComposableArchitecture
+import XCTest
+
+@testable import AppFeature
+
+final class QuickActionTests: XCTestCase {
+  func testDailyChallengeQuickAction() {
+    let store = TestStore(
+      initialState: .init(),
+      reducer: appReducer,
+      environment: .didFinishLaunching
+    )
+
+    store.send(.appDelegate(.didFinishLaunching))
+    store.send(.appDelegate(.scene(.quickAction(type: "dailyChallenge"))))
+    store.receive(.home(.setNavigation(tag: .dailyChallenge))) {
+      $0.home.route = .dailyChallenge(.init())
+    }
+  }
+
+  func testUnknownQuickAction() {
+    let store = TestStore(
+      initialState: .init(),
+      reducer: appReducer,
+      environment: .didFinishLaunching
+    )
+
+    store.send(.appDelegate(.didFinishLaunching))
+    store.send(.appDelegate(.scene(.quickAction(type: "unrecognizedQuickAction")))) // Expecting a no-op.
+  }
+}


### PR DESCRIPTION
Turns out using `@UIApplicationDelegateAdaptor` twice leads to some non-deterministic behavior. 😅

h/t @rvsrvs for pairing on this with me. ✅