### PR TITLE
Update player on main queue in API.

### DIFF
--- a/Sources/ApiClientLive/Live.swift
+++ b/Sources/ApiClientLive/Live.swift
@@ -67,7 +67,11 @@ extension ApiClient {
         )
         .map { data, _ in data }
         .apiDecode(as: CurrentPlayerEnvelope.self)
-        .handleEvents(receiveOutput: { currentPlayer = $0 })
+        .handleEvents(
+          receiveOutput: { newPlayer in
+            DispatchQueue.main.async { currentPlayer = newPlayer }
+          }
+        )
         .eraseToEffect()
       },
       baseUrl: { baseUrl },
@@ -84,7 +88,11 @@ extension ApiClient {
         )
         .map { data, _ in data }
         .apiDecode(as: CurrentPlayerEnvelope.self)
-        .handleEvents(receiveOutput: { currentPlayer = $0 })
+        .handleEvents(
+          receiveOutput: { newPlayer in
+            DispatchQueue.main.async { currentPlayer = newPlayer }
+          }
+        )
         .eraseToEffect()
       },
       request: { route in


### PR DESCRIPTION
While writing a response to https://github.com/pointfreeco/swift-composable-architecture/discussions/505 I realized we should synchronize the updates to `currentPlayer` in the live `ApiClient`.