### PR TITLE
Add app-clip-display to meta tags.

### DIFF
--- a/Sources/SiteMiddleware/Resources/index.html
+++ b/Sources/SiteMiddleware/Resources/index.html
@@ -24,10 +24,10 @@
   <!-- AppClip -->
   <meta
      name="apple-itunes-app"
-     content="app-clip-bundle-id=co.pointfree.IsoWordsTesting.Clip,app-id=1528246952">
+     content="app-clip-bundle-id=co.pointfree.IsoWordsTesting.Clip,app-id=1528246952,app-clip-display=card">
    <meta
      name="apple-itunes-app"
-     content="app-clip-bundle-id=co.pointfree.IsoWordsTesting.Clip,app-id=1528246952">
+     content="app-clip-bundle-id=co.pointfree.IsoWordsTesting.Clip,app-id=1528246952,app-clip-display=card">
 
   <!-- Meta -->
   <meta property="name" content="isowords" />


### PR DESCRIPTION
There's a WWDC video about app clips that shows how if you add this meta tag to a page Safari will prompt the user to open the app clip rather than having them open it from the banner.