### PR TITLE
Fix gitignore entry for root-level Package.resolved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ Assets/.swiftpm
 Bootstrap/.swiftpm
 Assets/Audio/*
 Audio.zip
-./Package.resolved
+/Package.resolved
 Sources/ApiClientLive/Secrets.swift
 Sources/AppAudioLibrary/Resources/**/*.caf
 Sources/AppAudioLibrary/Resources/**/*.mp3


### PR DESCRIPTION
I noticed that, after the recent "no workspace" simplification, the root-level `Package.resolved` file isn't properly ignore by Git.

Per the [Git docs](https://git-scm.com/docs/gitignore#_examples):

> The pattern `hello.*` matches any file or folder whose name begins with `hello.`. If one wants to restrict this only to the directory and not in its subdirectories, one can prepend the pattern with a slash, i.e. `/hello.*`; the pattern now matches `hello.txt`, `hello.c` but not `a/hello.java`.