### PR TITLE
Fix AudioPlayerClient's AudioActor count growth

### DIFF
--- a/App/iOS/App.swift
+++ b/App/iOS/App.swift
@@ -2,6 +2,7 @@ import ApiClientLive
 import AppAudioLibrary
 import AppClipAudioLibrary
 import AppFeature
+import AudioPlayerClient
 import Build
 import ComposableArchitecture
 import DictionarySqliteClient
@@ -15,7 +16,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
   let store = Store(
     initialState: AppReducer.State(),
     reducer: AppReducer().transformDependency(\.self) {
-      $0.audioPlayer = .live(bundles: [AppAudioLibrary.bundle, AppClipAudioLibrary.bundle])
+      $0.audioPlayer = .liveValue
       $0.database = .live(
         path: FileManager.default
           .urls(for: .documentDirectory, in: .userDomainMask)
@@ -71,6 +72,10 @@ struct IsowordsApp: App {
       self.appDelegate.viewStore.send(.didChangeScenePhase($0))
     }
   }
+}
+
+extension AudioPlayerClient {
+  static let liveValue = Self.live(bundles: [AppAudioLibrary.bundle, AppClipAudioLibrary.bundle])
 }
 
 extension ServerConfigClient {


### PR DESCRIPTION
Instruments show that number of AudioActor actors monotonically increases with app lifetime.
@tgrapperon helped to identify the cause being the argument passed to the actor that causes a new instance being created on every action passing AppReducer.

<img width="777" alt="image (1)" src="https://user-images.githubusercontent.com/205317/195714787-e049c8f9-721e-4c0c-b49d-107fba46b301.png">

Again, as per @tgrapperon suggestion, I've cached the live value in a static var, which resolves the issue.