### PR TITLE
Fix Settings from Home

### DIFF
--- a/Sources/DailyChallengeFeature/DailyChallengeView.swift
+++ b/Sources/DailyChallengeFeature/DailyChallengeView.swift
@@ -214,8 +214,8 @@ public struct DailyChallengeReducer: ReducerProtocol {
       }
     }
     .ifLet(\.destination, action: /Action.destination) {
-      EmptyReducer().ifCaseLet(
-        /DestinationState.results,
+      Scope(
+        state: /DestinationState.results,
         action: /DestinationAction.dailyChallengeResults
       ) {
         DailyChallengeResults()

--- a/Sources/DemoFeature/Demo.swift
+++ b/Sources/DemoFeature/Demo.swift
@@ -61,13 +61,12 @@ public struct Demo: ReducerProtocol {
 
   public var body: some ReducerProtocol<State, Action> {
     Scope(state: \.step, action: .self) {
-      EmptyReducer()
-        .ifCaseLet(
-          /State.Step.onboarding,
-          action: /Action.onboarding
-        ) {
-          Onboarding()
-        }
+      Scope(
+        state: /State.Step.onboarding,
+        action: /Action.onboarding
+      ) {
+        Onboarding()
+      }
     }
 
     IntegratedGame(

--- a/Sources/HomeFeature/Home.swift
+++ b/Sources/HomeFeature/Home.swift
@@ -159,6 +159,9 @@ public struct Home: ReducerProtocol {
   public init() {}
 
   public var body: some ReducerProtocol<State, Action> {
+    Scope(state: \.settings, action: /Action.settings) {
+      Settings()
+    }
     Reduce { state, action in
       switch action {
       case let .activeMatchesResponse(.success(response)):
@@ -372,10 +375,6 @@ public struct Home: ReducerProtocol {
 
     Scope(state: \.nagBanner, action: /Action.nagBannerFeature) {
       NagBannerFeature()
-    }
-    
-    Scope(state: \.settings, action: /Action.settings) {
-      Settings()
     }
   }
 

--- a/Sources/HomeFeature/Home.swift
+++ b/Sources/HomeFeature/Home.swift
@@ -344,35 +344,38 @@ public struct Home: ReducerProtocol {
       ChangelogReducer()
     }
     .ifLet(\.destination, action: /Action.destination) {
-      EmptyReducer()
-        .ifCaseLet(
-          /DestinationState.dailyChallenge,
-          action: /DestinationAction.dailyChallenge
-        ) {
-          DailyChallengeReducer()
-        }
-        .ifCaseLet(
-          /DestinationState.leaderboard,
-          action: /DestinationAction.leaderboard
-        ) {
-          Leaderboard()
-        }
-        .ifCaseLet(
-          /DestinationState.multiplayer,
-          action: /DestinationAction.multiplayer
-        ) {
-          Multiplayer()
-        }
-        .ifCaseLet(
-          /DestinationState.solo,
-          action: /DestinationAction.solo
-        ) {
-          Solo()
-        }
+      Scope(
+        state: /DestinationState.dailyChallenge,
+        action: /DestinationAction.dailyChallenge
+      ) {
+        DailyChallengeReducer()
+      }
+      Scope(
+        state: /DestinationState.leaderboard,
+        action: /DestinationAction.leaderboard
+      ) {
+        Leaderboard()
+      }
+      Scope(
+        state: /DestinationState.multiplayer,
+        action: /DestinationAction.multiplayer
+      ) {
+        Multiplayer()
+      }
+      Scope(
+        state: /DestinationState.solo,
+        action: /DestinationAction.solo
+      ) {
+        Solo()
+      }
     }
 
     Scope(state: \.nagBanner, action: /Action.nagBannerFeature) {
       NagBannerFeature()
+    }
+    
+    Scope(state: \.settings, action: /Action.settings) {
+      Settings()
     }
   }
 

--- a/Sources/HomeFeature/Home.swift
+++ b/Sources/HomeFeature/Home.swift
@@ -159,9 +159,6 @@ public struct Home: ReducerProtocol {
   public init() {}
 
   public var body: some ReducerProtocol<State, Action> {
-    Scope(state: \.settings, action: /Action.settings) {
-      Settings()
-    }
     Reduce { state, action in
       switch action {
       case let .activeMatchesResponse(.success(response)):
@@ -375,6 +372,10 @@ public struct Home: ReducerProtocol {
 
     Scope(state: \.nagBanner, action: /Action.nagBannerFeature) {
       NagBannerFeature()
+    }
+    
+    Scope(state: \.settings, action: /Action.settings) {
+      Settings()
     }
   }
 

--- a/Sources/MultiplayerFeature/MultiplayerView.swift
+++ b/Sources/MultiplayerFeature/MultiplayerView.swift
@@ -70,8 +70,8 @@ public struct Multiplayer: ReducerProtocol {
       }
     }
     .ifLet(\.destination, action: /Action.destination) {
-      EmptyReducer().ifCaseLet(
-        /DestinationState.pastGames,
+      Scope(
+        state: /DestinationState.pastGames,
         action: /DestinationAction.pastGames
       ) {
         PastGames()

--- a/Sources/StatsFeature/StatsFeature.swift
+++ b/Sources/StatsFeature/StatsFeature.swift
@@ -120,8 +120,8 @@ public struct Stats: ReducerProtocol {
       }
     }
     .ifLet(\.destination, action: /Action.destination) {
-      EmptyReducer().ifCaseLet(
-        /DestinationState.vocab,
+      Scope(
+        state: /DestinationState.vocab,
         action: /DestinationAction.vocab
       ) {
         Vocab()


### PR DESCRIPTION
This reinstalls the `Setting` reducer in `Home` reducer. It was most likely left behind during the "protocol" conversion. 

As `Reduce` and the other `ifLet` reducers are not effectively handling `.settings` actions, they all commute with `Settings`, so this reducer can be installed arbitrarily at the end of the reducer's chain with the other child reducers.

This should fix #170

I also took the liberty to modernize homogenous `EmptyReducer().ifCaseLet…` into `Scope(state: /CasePath…`, but I can revert if you prefer.