### PR TITLE
Add explicit module namespace to usages of func `unimplemented` on `ServerEnvironment.unimplemented`

### DIFF
--- a/Sources/SiteMiddleware/ServerEnvironment.swift
+++ b/Sources/SiteMiddleware/ServerEnvironment.swift
@@ -53,14 +53,14 @@ public struct ServerEnvironment {
 
   extension ServerEnvironment {
     public static let unimplemented = Self(
-      changelog: unimplemented("\(Self.self).changelog", placeholder: .current),
+      changelog: XCTestDynamicOverlay.unimplemented("\(Self.self).changelog", placeholder: .current),
       database: .unimplemented,
-      date: unimplemented("\(Self.self).date", placeholder: Date()),
+      date: XCTestDynamicOverlay.unimplemented("\(Self.self).date", placeholder: Date()),
       dictionary: .testValue,
       envVars: EnvVars(appEnv: .testing),
       itunes: .unimplemented,
       mailgun: .unimplemented,
-      randomCubes: unimplemented("\(Self.self).randomCubes", placeholder: .mock),
+      randomCubes: XCTestDynamicOverlay.unimplemented("\(Self.self).randomCubes", placeholder: .mock),
       router: .unimplemented,
       snsClient: .unimplemented
     )


### PR DESCRIPTION
I wanted to run the server app but faced some compiler errors:

<img width="1084" alt="Screenshot 2023-05-18 at 22 06 04" src="https://github.com/pointfreeco/isowords/assets/14075359/0bf09a43-57ab-4de9-97c9-bc33faae7709">

To make it compile again I added the explicit namespace of the module on calls to `unimplemented()`
Seems Swift does have issues with the naming. 
I am following a lot of the best practices applied in this and other repos of pointfree and while renaming some `static let test: Self` to `unimplemented` I also encountered some issues with the naming of properties.

I am happy to drill down to the root of the issue if you can give me a pointer :) 