### PR TITLE
Fixes a bug in UserDefaultsClient’s override methods

### DIFF
--- a/Sources/UserDefaultsClient/TestKey.swift
+++ b/Sources/UserDefaultsClient/TestKey.swift
@@ -32,18 +32,18 @@ extension UserDefaultsClient {
   )
 
   public mutating func override(bool: Bool, forKey key: String) {
-    self.boolForKey = { [self] in $0 == key ? bool : self.boolForKey(key) }
+    self.boolForKey = { [self] in $0 == key ? bool : self.boolForKey($0) }
   }
 
   public mutating func override(data: Data, forKey key: String) {
-    self.dataForKey = { [self] in $0 == key ? data : self.dataForKey(key) }
+    self.dataForKey = { [self] in $0 == key ? data : self.dataForKey($0) }
   }
 
   public mutating func override(double: Double, forKey key: String) {
-    self.doubleForKey = { [self] in $0 == key ? double : self.doubleForKey(key) }
+    self.doubleForKey = { [self] in $0 == key ? double : self.doubleForKey($0) }
   }
 
   public mutating func override(integer: Int, forKey key: String) {
-    self.integerForKey = { [self] in $0 == key ? integer : self.integerForKey(key) }
+    self.integerForKey = { [self] in $0 == key ? integer : self.integerForKey($0) }
   }
 }


### PR DESCRIPTION
Fixes a bug where overriding a UserDefaults key would not fall back to the default/previous implementation when the value for a different key is requested