### PR TITLE
Fix problems with archive by making certain reducers public.

### DIFF
--- a/Sources/GameCore/Drawer.swift
+++ b/Sources/GameCore/Drawer.swift
@@ -1,12 +1,12 @@
 import ActiveGamesFeature
 import ComposableArchitecture
 
-struct ActiveGamesTray: Reducer {
+public struct ActiveGamesTray: Reducer {
   @Dependency(\.fileClient) var fileClient
   @Dependency(\.gameCenter) var gameCenter
   @Dependency(\.mainRunLoop.now.date) var now
 
-  var body: some ReducerOf<Game> {
+  public var body: some ReducerOf<Game> {
     Reduce { state, action in
       switch action {
       case .cancelButtonTapped,

--- a/Sources/GameCore/GameOver.swift
+++ b/Sources/GameCore/GameOver.swift
@@ -2,10 +2,10 @@ import ComposableArchitecture
 import GameOverFeature
 import SharedModels
 
-struct GameOverLogic: Reducer {
+public struct GameOverLogic: Reducer {
   @Dependency(\.database.saveGame) var saveGame
 
-  var body: some ReducerOf<Game> {
+  public var body: some ReducerOf<Game> {
     Reduce { state, action in
       var allCubesRemoved: Bool {
         state.cubes.allSatisfy {

--- a/Sources/GameCore/SoundsCore.swift
+++ b/Sources/GameCore/SoundsCore.swift
@@ -4,11 +4,11 @@ import SelectionSoundsCore
 
 extension Reducer<Game.State, Game.Action> {
   func sounds() -> some Reducer<Game.State, Game.Action> {
-    GameSounds(base: self)
+    _GameSounds(base: self)
   }
 }
 
-private struct GameSounds<Base: Reducer<Game.State, Game.Action>>: Reducer {
+public struct _GameSounds<Base: Reducer<Game.State, Game.Action>>: Reducer {
   @Dependency(\.audioPlayer) var audioPlayer
   @Dependency(\.date) var date
   @Dependency(\.dictionary.contains) var dictionaryContains
@@ -18,7 +18,7 @@ private struct GameSounds<Base: Reducer<Game.State, Game.Action>>: Reducer {
 
   enum CancelID { case cubeShaking }
 
-  var body: some Reducer<Game.State, Game.Action> {
+  public var body: some Reducer<Game.State, Game.Action> {
     self.core
       .onChange(of: { /Game.Destination.State.gameOver ~= $0.destination }) { _, _ in
         Reduce { _, _ in

--- a/Sources/GameCore/TurnBased.swift
+++ b/Sources/GameCore/TurnBased.swift
@@ -4,14 +4,14 @@ import Foundation
 import GameOverFeature
 import SharedModels
 
-struct TurnBasedLogic: Reducer {
+public struct TurnBasedLogic: Reducer {
   @Dependency(\.apiClient) var apiClient
   @Dependency(\.feedbackGenerator) var feedbackGenerator
   @Dependency(\.gameCenter) var gameCenter
   @Dependency(\.mainRunLoop.now.date) var now
   @Dependency(\.database.saveGame) var saveGame
 
-  var body: some ReducerOf<Game> {
+  public var body: some ReducerOf<Game> {
     Reduce { state, action in
       guard let turnBasedContext = state.turnBasedContext
       else { return .none }

--- a/Sources/TcaHelpers/FilterReducer.swift
+++ b/Sources/TcaHelpers/FilterReducer.swift
@@ -5,12 +5,11 @@ extension Reducer {
   public func filter(
     _ predicate: @escaping (State, Action) -> Bool
   ) -> some ReducerOf<Self> {
-    FilterReducer(base: self, predicate: predicate)
+    _FilterReducer(base: self, predicate: predicate)
   }
 }
 
-@usableFromInline
-struct FilterReducer<Base: Reducer>: Reducer {
+public struct _FilterReducer<Base: Reducer>: Reducer {
   @usableFromInline
   let base: Base
 


### PR DESCRIPTION
The archive of isowords was failing with "undefined symbols" errors, like this:

> ld: warning: Could not find or use auto-linked framework 'CoreAudioTypes': framework 'CoreAudioTypes' not found
ld: Undefined symbols:
  nominal type descriptor for GameCore.GameOverLogic, referenced from:
      _symbolic _____y_____y_____y_____y_____y___________AEyAfG_AEyAfG_AEyAfG______yAfGG_____yAfG_____GG_____G_____G_____GSay_____GAIGG_____GG 8GameCore01_A6SoundsV 22ComposableArchitecture20_PresentationReducerV 10TcaHelpers06FilterG0V AD09_OnChangeG0V AD0G7BuilderO9_SequenceV AA0A0V5StateV AQ6ActionO AD6ReduceV AD5ScopeV AA23WordSubmitButtonFeatureV AA0A9OverLogicV AA09TurnBasedX0V AA15ActiveGamesTrayV 12SharedModels15IndexedCubeFaceV AQ11DestinationV in DemoFeature.o

It looks like there is a bug in the Swift compiler that is perhaps being too zealous in removing private types, and so we had to make some things public.