### PR TITLE
Remove `firstLaunchOnboarding`

### DIFF
--- a/Sources/AppFeature/AppView.swift
+++ b/Sources/AppFeature/AppView.swift
@@ -46,22 +46,6 @@ public struct AppReducer {
       self.destination = destination
       self.home = home
     }
-
-    var firstLaunchOnboarding: Onboarding.State? {
-      switch self.destination {
-      case .game, .none:
-        return nil
-
-      case let .onboarding(onboarding):
-        switch onboarding.presentationStyle {
-        case .demo, .help:
-          return nil
-
-        case .firstLaunch:
-          return onboarding
-        }
-      }
-    }
   }
 
   public enum Action {


### PR DESCRIPTION
Hi 👋🏽 
I couldn't find anywhere using the computed property `firstLaunchOnboarding` of `RootReducer.State`.

So I'm removing it in case it is unnecessary.